### PR TITLE
dual support

### DIFF
--- a/speech/detector.go
+++ b/speech/detector.go
@@ -12,6 +12,7 @@ import (
 )
 
 const (
+	hcLen      = 2 * 1 * 64
 	stateLen   = 2 * 1 * 128
 	contextLen = 64
 )
@@ -92,8 +93,13 @@ type Detector struct {
 
 	cfg DetectorConfig
 
+	// v5+
 	state [stateLen]float32
 	ctx   [contextLen]float32
+
+	// v4
+	h [hcLen]float32
+	c [hcLen]float32
 
 	currSample int
 	triggered  bool
@@ -163,7 +169,11 @@ func NewDetector(cfg DetectorConfig) (*Detector, error) {
 	sd.cStrings["sr"] = C.CString("sr")
 	sd.cStrings["state"] = C.CString("state")
 	sd.cStrings["stateN"] = C.CString("stateN")
+	sd.cStrings["h"] = C.CString("h")
+	sd.cStrings["c"] = C.CString("c")
 	sd.cStrings["output"] = C.CString("output")
+	sd.cStrings["hn"] = C.CString("hn")
+	sd.cStrings["cn"] = C.CString("cn")
 
 	return &sd, nil
 }
@@ -252,6 +262,14 @@ func (sd *Detector) Detect(pcm []float32) ([]Segment, error) {
 }
 
 func (sd *Detector) DetectWindows(pcm []float32) ([]float32, error) {
+	return sd.detectWindows(pcm, true)
+}
+
+func (sd *Detector) DetectWindowsV4(pcm []float32) ([]float32, error) {
+	return sd.detectWindows(pcm, false)
+}
+
+func (sd *Detector) detectWindows(pcm []float32, v5 bool) ([]float32, error) {
 	if sd == nil {
 		return nil, fmt.Errorf("invalid nil detector")
 	}
@@ -272,7 +290,13 @@ func (sd *Detector) DetectWindows(pcm []float32) ([]float32, error) {
 	windows := make([]float32, len(pcm)/windowSize)
 
 	for i := 0; i < len(windows); i++ {
-		speechProb, err := sd.Infer(pcm[i*windowSize : (i+1)*windowSize])
+		var speechProb float32
+		var err error
+		if v5 {
+			speechProb, err = sd.Infer(pcm[i*windowSize : (i+1)*windowSize])
+		} else {
+			speechProb, err = sd.InferV4(pcm[i*windowSize : (i+1)*windowSize])
+		}
 		if err != nil {
 			return nil, fmt.Errorf("infer failed: %w", err)
 		}
@@ -294,6 +318,10 @@ func (sd *Detector) Reset() error {
 	}
 	for i := 0; i < contextLen; i++ {
 		sd.ctx[i] = 0
+	}
+	for i := 0; i < hcLen; i++ {
+		sd.h[i] = 0
+		sd.c[i] = 0
 	}
 
 	return nil

--- a/speech/infer_darwin.go
+++ b/speech/infer_darwin.go
@@ -88,3 +88,100 @@ func (sd *Detector) Infer(pcm []float32) (float32, error) {
 	// Return speech probability
 	return *(*float32)(prob), nil
 }
+
+func (sd *Detector) InferV4(pcm []float32) (float32, error) {
+	// Create tensors
+	var pcmValue *C.OrtValue
+	pcmInputDims := []C.longlong{
+		1,
+		C.longlong(len(pcm)),
+	}
+	status := C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&pcm[0]), C.size_t(len(pcm)*4), &pcmInputDims[0], C.size_t(len(pcmInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &pcmValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, pcmValue)
+
+	var rateValue *C.OrtValue
+	rateInputDims := []C.longlong{1}
+	rate := []C.int64_t{C.int64_t(sd.cfg.SampleRate)}
+	status = C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&rate[0]), C.size_t(8), &rateInputDims[0], C.size_t(len(rateInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &rateValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, rateValue)
+
+	hcNodeInputDims := []C.longlong{2, 1, 64}
+
+	var hValue *C.OrtValue
+	status = C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&sd.h[0]), C.size_t(hcLen*4), &hcNodeInputDims[0], C.size_t(len(hcNodeInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &hValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, hValue)
+
+	var cValue *C.OrtValue
+	status = C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&sd.c[0]), C.size_t(hcLen*4), &hcNodeInputDims[0], C.size_t(len(hcNodeInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &cValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, cValue)
+
+	// Run inference
+	inputs := []*C.OrtValue{pcmValue, rateValue, hValue, cValue}
+	outputs := []*C.OrtValue{nil, nil, nil}
+
+	inputNames := []*C.char{
+		sd.cStrings["input"],
+		sd.cStrings["sr"],
+		sd.cStrings["h"],
+		sd.cStrings["c"],
+	}
+	outputNames := []*C.char{
+		sd.cStrings["output"],
+		sd.cStrings["hn"],
+		sd.cStrings["cn"],
+	}
+	status = C.OrtApiRun(sd.api, sd.session, nil, &inputNames[0], &inputs[0], C.size_t(len(inputNames)), &outputNames[0], C.size_t(len(outputNames)), &outputs[0])
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to run: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	// Get output values from tensor data
+	var prob unsafe.Pointer
+	var hn unsafe.Pointer
+	var cn unsafe.Pointer
+
+	status = C.OrtApiGetTensorMutableData(sd.api, outputs[0], &prob)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to get tensor data: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	status = C.OrtApiGetTensorMutableData(sd.api, outputs[1], &hn)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to get tensor data: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	status = C.OrtApiGetTensorMutableData(sd.api, outputs[2], &cn)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to get tensor data: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	C.memcpy(unsafe.Pointer(&sd.h[0]), hn, hcLen*4)
+	C.memcpy(unsafe.Pointer(&sd.c[0]), cn, hcLen*4)
+
+	C.OrtApiReleaseValue(sd.api, outputs[0])
+	C.OrtApiReleaseValue(sd.api, outputs[1])
+	C.OrtApiReleaseValue(sd.api, outputs[2])
+
+	// Return speech probability
+	return *(*float32)(prob), nil
+}

--- a/speech/infer_linux.go
+++ b/speech/infer_linux.go
@@ -96,3 +96,100 @@ func (sd *Detector) Infer(samples []float32) (float32, error) {
 	// Return speech probability
 	return *(*float32)(prob), nil
 }
+
+func (sd *Detector) InferV4(pcm []float32) (float32, error) {
+	// Create tensors
+	var pcmValue *C.OrtValue
+	pcmInputDims := []C.long{
+		1,
+		C.long(len(pcm)),
+	}
+	status := C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&pcm[0]), C.size_t(len(pcm)*4), &pcmInputDims[0], C.size_t(len(pcmInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &pcmValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, pcmValue)
+
+	var rateValue *C.OrtValue
+	rateInputDims := []C.long{1}
+	rate := []C.int64_t{C.int64_t(sd.cfg.SampleRate)}
+	status = C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&rate[0]), C.size_t(8), &rateInputDims[0], C.size_t(len(rateInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_INT64, &rateValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, rateValue)
+
+	hcNodeInputDims := []C.long{2, 1, 64}
+
+	var hValue *C.OrtValue
+	status = C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&sd.h[0]), C.size_t(hcLen*4), &hcNodeInputDims[0], C.size_t(len(hcNodeInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &hValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, hValue)
+
+	var cValue *C.OrtValue
+	status = C.OrtApiCreateTensorWithDataAsOrtValue(sd.api, sd.memoryInfo, unsafe.Pointer(&sd.c[0]), C.size_t(hcLen*4), &hcNodeInputDims[0], C.size_t(len(hcNodeInputDims)), C.ONNX_TENSOR_ELEMENT_DATA_TYPE_FLOAT, &cValue)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to create value: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+	defer C.OrtApiReleaseValue(sd.api, cValue)
+
+	// Run inference
+	inputs := []*C.OrtValue{pcmValue, rateValue, hValue, cValue}
+	outputs := []*C.OrtValue{nil, nil, nil}
+
+	inputNames := []*C.char{
+		sd.cStrings["input"],
+		sd.cStrings["sr"],
+		sd.cStrings["h"],
+		sd.cStrings["c"],
+	}
+	outputNames := []*C.char{
+		sd.cStrings["output"],
+		sd.cStrings["hn"],
+		sd.cStrings["cn"],
+	}
+	status = C.OrtApiRun(sd.api, sd.session, nil, &inputNames[0], &inputs[0], C.size_t(len(inputNames)), &outputNames[0], C.size_t(len(outputNames)), &outputs[0])
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to run: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	// Get output values from tensor data
+	var prob unsafe.Pointer
+	var hn unsafe.Pointer
+	var cn unsafe.Pointer
+
+	status = C.OrtApiGetTensorMutableData(sd.api, outputs[0], &prob)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to get tensor data: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	status = C.OrtApiGetTensorMutableData(sd.api, outputs[1], &hn)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to get tensor data: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	status = C.OrtApiGetTensorMutableData(sd.api, outputs[2], &cn)
+	defer C.OrtApiReleaseStatus(sd.api, status)
+	if status != nil {
+		return 0, fmt.Errorf("failed to get tensor data: %s", C.GoString(C.OrtApiGetErrorMessage(sd.api, status)))
+	}
+
+	C.memcpy(unsafe.Pointer(&sd.h[0]), hn, hcLen*4)
+	C.memcpy(unsafe.Pointer(&sd.c[0]), cn, hcLen*4)
+
+	C.OrtApiReleaseValue(sd.api, outputs[0])
+	C.OrtApiReleaseValue(sd.api, outputs[1])
+	C.OrtApiReleaseValue(sd.api, outputs[2])
+
+	// Return speech probability
+	return *(*float32)(prob), nil
+}


### PR DESCRIPTION
- Experiment for running/testing v4 and v5+ models in same binary without running into the backwards compatibility issues (v4/v5 have slight differences, linker has naming collisions if you try to use an old version + newer version as separate modules)